### PR TITLE
Simpler respStmt, so that it validates with vanilla tei_odds

### DIFF
--- a/Specification/standoff-proposal.xml
+++ b/Specification/standoff-proposal.xml
@@ -7,18 +7,8 @@
         <fileDesc>
             <titleStmt>
                 <title>Proposal for encoding standoff annotations in TEI</title>
-                <author>
-                    <persName>
-                        <forename>Peter</forename>
-                        <surname>Stadler</surname>
-                    </persName>
-                </author>
-                <author>
-                    <persName>
-                        <forename>Laurent</forename>
-                        <surname>Romary</surname>
-                    </persName>
-                </author>
+                <author>Peter Stadler</author>
+                <author>Laurent Romary</author>
             </titleStmt>
             <publicationStmt>
                 <authority>Berlin task force "standoff"</authority>


### PR DESCRIPTION
This is to show what I meant in issue #11. If this is acceptable, I can modify the pure ODD accordingly and add the newest tei_odds.rnc to this pull request.